### PR TITLE
feat: new endpoint to extract info from orcid

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ docker-compose up # add -d for detached
 or
 
 ``` bash
-docker build -t gimieapi .
-docker run --env-file .env -p 7005:15400 gimieapi
+docker build -t gimie-api .
+docker run --env-file .env -p 7005:15400 gimie-api
 ```
 
-This will serve a instance running by default in port 7123. 
+This will serve a instance running by default in port 7123.
 
 
 ## How to use the API
@@ -44,8 +44,16 @@ http://0.0.0.0:7123/gimie/ttl/https://github.com/SDSC-ORD/gimie
 http://localhost:8000/docs
 ```
 
+## How to develop?
+
+``` bash
+docker build -t gimie-api .
+docker run --env-file .env -p 7005:15400 -it --entrypoint bash -v app:/app gimie-api -c "uvicorn app.main:app --host 0.0.0.0 --port 15400"
+```
+
 ## Changelog
 
+- v0.2.0: Including orcid parsing
 - v0.1.0: Updating gimie to release [0.7.0](https://github.com/sdsc-ordes/gimie/releases/tag/v0.7.2)
 - v0.0.2: Updating gimie to release  [0.6.0](https://github.com/SDSC-ORD/gimie/releases/tag/0.6.0).
 - v0.0.1: Basic service using main branch from gimie.

--- a/app/main.py
+++ b/app/main.py
@@ -1,18 +1,18 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Query
 from fastapi.responses import JSONResponse
 import os
 from gimie.project import Project
+import json
+from pprint import pprint
 
+from .orcid import run_analysis_from_github_username
+from .semantics import filter_person_with_github
 
 app = FastAPI()
 
 @app.get("/")
 def index():
     return {"title": "Hello, welcome to the Gimie API v0.1.0. Gimie Version 0.7.2"}
-
-@app.get("/test/{string}")
-async def test(string):
-    return {"output": string}
 
 @app.get("/gimie/project/{full_path:path}")
 async def gimieJSON(full_path:str):
@@ -57,6 +57,82 @@ async def gimie_jsonld(full_path:str):
         return {"link": full_path, "output": output}
     except Exception as e:
         return {"link": full_path, "output": e}
+    
+
+### V2
+
+@app.get("/v2/repository/getgimie/jsonld/{full_path:path}")
+async def v2_repository_jsonld(
+    full_path: str,
+    output_type: str = Query("json", regex="^(string|json)$")
+):
+    try:
+        proj = Project(full_path)
+
+        # To retrieve the rdflib.Graph object
+        g = proj.extract()
+
+        # To retrieve the serialized graph
+        output = g.serialize(format='json-ld')
+
+        if output_type == "json":
+            jsonld = json.loads(output)
+            return {"link": full_path, "output": jsonld}
+        else:
+            return {"link": full_path, "output": output}
+    except Exception as e:
+        return {"link": full_path, "output": f"Error: {e}"}
+
+@app.get("/v2/repository/getorcids/json/{full_path:path}")
+async def v2_repository_jsonld(
+    full_path: str
+):
+    try:
+        proj = Project(full_path)
+
+        # To retrieve the rdflib.Graph object
+        g = proj.extract()
+
+        # To retrieve the serialized graph
+        output = g.serialize(format='json-ld')
+
+        jsonld = json.loads(output)
+
+        github_persons = filter_person_with_github(jsonld)
+
+        orcid_records = []
+        for person in github_persons:
+
+            # In some cases the run_analysis_from_github_username is 
+            try:
+                output = run_analysis_from_github_username(person["http://schema.org/identifier"][0]["@value"])
+
+                if output is not None:
+                    orcid_records.append({
+                        '@id': person["@id"],
+                        'orcid': output
+                    })
+            except Exception as e:
+                print (f"Error: {e}, {person["@id"]}")
+                pass
+
+        return {"url": full_path, "output": orcid_records}
+
+    except Exception as e:
+        return {"url": full_path, "output": f"Error: {e}"}
+    
+    
+@app.get("/v2/user/getorcid/json/{git_username}")
+async def v2_repository_jsonld(
+    git_username: str
+):
+    try:
+        output = run_analysis_from_github_username(git_username)
+        return {"username": git_username, "output": output}
+    
+    except Exception as e:
+        return {"username": git_username, "output": f"Error: {e}"}
+
 
 @app.exception_handler(ValueError)
 async def value_error_exception_handler(request: Request, exc: ValueError):

--- a/app/orcid.py
+++ b/app/orcid.py
@@ -1,0 +1,158 @@
+# USER FLOW
+
+# Download user html
+from dataclasses import dataclass, asdict
+import json
+import re
+import sys
+from typing import Optional
+
+from bs4 import BeautifulSoup
+import requests
+import argparse
+
+@dataclass
+class Organization:
+    name: str
+    country: str
+    ror: Optional[str]
+
+    @classmethod
+    def from_dict(cls, data: dict):
+
+        ror = None
+        try:
+            org_id = data['disambiguated-organization']
+            if org_id['disambiguation-source'] == 'ROR':
+                ror = org_id['disambiguated-organization-identifier'] 
+        except KeyError:
+            # NOTE: if no ror id, we could also search org name using ROR API
+            # but it would be error prone and slower.
+            pass
+
+        return Organization(
+            name=data['name'],
+            country=data['address']['country'],
+            ror=ror,
+        )
+
+@dataclass
+class Affiliation:
+    organization: Organization
+    start_year: Optional[int]
+    end_year: Optional[int]
+
+    @classmethod
+    def from_dict(cls, data: dict):
+
+        org = Organization.from_dict(data['organization'])
+        get_date = lambda x: int(x['year']['value']) if x else None
+        return cls(
+            organization=org ,
+            start_year=get_date(data['start-date']),
+            end_year=get_date(data['end-date']),
+        )
+
+@dataclass
+class OrcidRecord:
+    educations: list[Affiliation]
+    employments: list[Affiliation]
+
+    @classmethod
+    def from_url(cls, url: str):
+        """Instantiate a record from an ORCiD API url"""
+        response = requests.get(url, headers={'Accept': 'application/json'})
+        return cls.from_dict(response.json())
+
+    @classmethod
+    def from_dict(cls, record_data: dict):
+        """Instantiate a record from an ORCiD API json response"""
+        employments = []
+        educations = []
+        activities = record_data['activities-summary']
+        for group in activities['educations']['affiliation-group']:
+            for edu in group['summaries']:
+                educations.append(Affiliation.from_dict(edu['education-summary']))
+
+        for group in activities['employments']['affiliation-group']:
+            for employ in group['summaries']:
+                employments.append(Affiliation.from_dict(employ['employment-summary']))
+        
+
+        return cls(
+            educations=educations,
+            employments=employments,
+        )
+
+    def __str__(self):
+        """str conversion pretty-prints the record and all its members as indented json."""
+        return json.dumps(asdict(self), ensure_ascii=False, indent=2)
+
+
+
+def get_orcid_from_github(username):
+    """Extracts the ORCID link from a GitHub user's profile, restricted to the vcard section."""
+    url = f"https://github.com/{username}"
+    
+    response = requests.get(url)
+    # TODO retry (3x)
+    if response.status_code != 200:
+        print(f"Failed to fetch page. Status code: {response.status_code}")
+        return None
+    
+    soup = BeautifulSoup(response.text, "html.parser")
+    
+    # Find the vcard section
+    
+    vcard_section = soup.find("ul", attrs={"class": "vcard-details"})
+
+    # Find all links within the vcard section
+    links = vcard_section.find_all("a", href=True)
+    
+    # Search for ORCID link
+    orcid_pattern = re.compile(r"https?://orcid\.org/\d{4}-\d{4}-\d{4}-\d{4}")
+    for link in links:
+        if orcid_pattern.match(link["href"]):
+            return link["href"]
+    
+    return None
+
+
+def fetch_orcid_record(orcid: str) -> OrcidRecord:
+    url = f"https://pub.orcid.org/v3.0/{orcid}"
+    print(url)
+    return OrcidRecord.from_url(url)
+
+def run_analysis_from_github_username(github_username):
+    # Extract ORCID
+    orcid_link = get_orcid_from_github(github_username)
+
+    if orcid_link:
+        print(f"ORCID Link found: {orcid_link}")
+        orcid_id = orcid_link.removeprefix("https://orcid.org/")
+        orcid_record = fetch_orcid_record(orcid_id)
+
+        return orcid_record
+    else:
+        print("No ORCID link found on this profile.")
+        return None
+
+def run_analysis_from_orcid(orcid_link):
+    print(f"ORCID Link found: {orcid_link}")
+    orcid_id = orcid_link.removeprefix("https://orcid.org/")
+    orcid_record = fetch_orcid_record(orcid_id)
+
+    return orcid_record
+    
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Extract ORCID record from GitHub username.")
+    parser.add_argument("github_username", type=str, help="GitHub username to extract ORCID from")
+    args = parser.parse_args()
+
+    github_username = args.github_username
+
+    orcid_record = run_analysis_from_github_username(github_username)
+
+    if not orcid_record:
+        exit()

--- a/app/semantics.py
+++ b/app/semantics.py
@@ -1,0 +1,43 @@
+
+# This method only retrieve github positives entries
+def filter_person_with_github(data):
+    """
+    Filters JSON-LD data to return entries that:
+    - Have an "@type" containing "schema.org/Person".
+    - Have an "@id" that includes "github.com".
+
+    Args:
+        data: The JSON-LD data (dict or list).
+
+    Returns:
+        A list of matching entries.
+    """
+
+    def is_person(entry):
+        types = entry.get('@type', [])
+        # Ensure types is a list for consistency.
+        if not isinstance(types, list):
+            types = [types]
+        return any("schema.org/Person" in t for t in types)
+
+    def has_github_id(entry):
+        return "github.com" in entry.get('@id', "")
+
+    result = []
+
+    # If data contains a graph list or is already a list.
+    if isinstance(data, dict):
+        if '@graph' in data and isinstance(data['@graph'], list):
+            entries = data['@graph']
+        else:
+            entries = [data]
+    elif isinstance(data, list):
+        entries = data
+    else:
+        entries = []
+
+    for entry in entries:
+        if isinstance(entry, dict) and is_person(entry) and has_github_id(entry):
+            result.append(entry)
+
+    return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 gimie==0.7.2
 pyyaml
+beautifulsoup4


### PR DESCRIPTION
- Added `/v2/` endpoints:

- `/v2/repository/getgimie/jsonld/{full_path:path}`. This one allows to retrieve gimie in json format instead of an string of `jsonld`. Backwards compatibility is still assured via the `output_type=string` query parameter. 
- `/v2/repository/getorcids/json/{full_path:path}`. It get all the affiliation information from  all person's items. 
- `/v2/user/getorcid/json/{git_username}`. It provides the orcid affiliation of one username. 

